### PR TITLE
JSON schema's voor de lidbestanden

### DIFF
--- a/index/$schema.json
+++ b/index/$schema.json
@@ -1,0 +1,158 @@
+{
+	"$schema": "http://json-schema.org/draft-06/schema",
+	"$id": "https://github.com/frontcore-io/index/index/$schema.json",
+	"title": "Frontcore IO Developer Schema",
+	"definitions": {
+		"languageCapabilities": {
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "#/definitions/skillLevel"
+				},
+				{
+					"properties": {
+						"languages": {
+							"description": "The languages you're familiar/proficient with.",
+							"$ref": "#/definitions/stringArray"
+						},
+						"frameworks": {
+							"description": "The frameworks you're familiar/proficient with.",
+							"$ref": "#/definitions/stringArray"
+						},
+						"techniques": {
+							"description": "The techniques you're familiar/proficient with.",
+							"$ref": "#/definitions/stringArray"
+						}
+					}
+				}
+			]
+		},
+		"phoneNumber": {
+			"type": "string",
+			"pattern": "^[0-9]{10}$"
+		},
+		"skillLevel": {
+			"type": "object",
+			"properties": {
+				"level": {
+					"description": "Mastery of this category.",
+					"$ref": "#/definitions/skillLevelEnum"
+				}
+			},
+			"required": [
+				"level"
+			]
+		},
+		"skillLevelEnum": {
+			"enum": [
+				"-----",
+				"*----",
+				"**---",
+				"***--",
+				"****-",
+				"*****"
+			]
+		},
+		"stringArray": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			},
+			"uniqueItems": true,
+			"default": []
+		}
+	},
+	"type": "object",
+	"properties": {
+		"$schema": {
+			"description": "That thing that validates this JSON.",
+			"type": "string",
+			"format": "uri"
+		},
+		"joinDate": {
+			"description": "The date you joined Frontcore.",
+			"type": "string",
+			"format": "date-time"
+		},
+		"firstName": {
+			"description": "Your first name.",
+			"type": "string",
+			"required": []
+		},
+		"lastNamePrefix": {
+			"description": "(Optional) Your last name prefix ('tussenvoegsel').",
+			"type": "string"
+		},
+		"lastName": {
+			"description": "Your last name.",
+			"type": "string",
+			"required": []
+		},
+		"phone": {
+			"description": "(Optional) Phone number you can be reached at.",
+			"$ref": "#/definitions/phoneNumber"
+		},
+		"email": {
+			"description": "(Optional) Email address you can be reached at.",
+			"type": "string",
+			"format": "email"
+		},
+		"url": {
+			"description": "(Optional) Link to your own website.",
+			"type": "string",
+			"format": "url"
+		},
+		"linkedIn": {
+			"description": "(Optional) Link to your LinkedIn profile.",
+			"type": "string",
+			"format": "url",
+			"pattern": "^https://(www.)?linkedin.com/in/"
+		},
+		"gitHub": {
+			"description": "(Optional) Link to your GitHub profile.",
+			"type": "string",
+			"format": "url",
+			"pattern": "^https://(www.)?github.com/"
+		},
+		"consultancy": {
+			"description": "(Optional) How high you'd rate your consultancy abilities.",
+			"$ref": "#/definitions/skillLevel",
+			"additionalProperties": false
+		},
+		"lead": {
+			"description": "(Optional) How high you'd rate your leadership abilities.",
+			"$ref": "#/definitions/skillLevel",
+			"additionalProperties": false
+		},
+		"design": {
+			"description": "(Optional) Design capabilties.",
+			"allOf": [
+				{
+					"$ref": "#/definitions/skillLevel"
+				},
+				{
+					"properties": {
+						"skills": {
+							"description": "List of your design skills.",
+							"$ref": "#/definitions/stringArray"
+						}
+					}
+				}
+			]
+		},
+		"frontend": {
+			"description": "(Optional) Frontend capabilities.",
+			"$ref": "#/definitions/languageCapabilities"
+		},
+		"backend": {
+			"description": "(Optional) Backend capabilities.",
+			"$ref": "#/definitions/languageCapabilities"
+		}
+	},
+	"required": [
+		"joinDate",
+		"firstName",
+		"lastName"
+	],
+	"additionalProperties": false
+}

--- a/index/$schema.json
+++ b/index/$schema.json
@@ -44,13 +44,44 @@
 			]
 		},
 		"skillLevelEnum": {
-			"enum": [
-				"-----",
-				"*----",
-				"**---",
-				"***--",
-				"****-",
-				"*****"
+			"description": "Your experience in this proficiency.",
+			"oneOf": [
+				{
+					"description": "No experience. You really shouldn't list this unless necessary.",
+					"enum": [
+						"-----"
+					]
+				},
+				{
+					"description": "Fundamental awareness: you have a common knowledge or an understanding of basic techniques and concepts.",
+					"enum": [
+						"*----"
+					]
+				},
+				{
+					"description": "Novice: you have the level of experience gained in a classroom and/or experimental scenarios or as a trainee on-the-job. You are expected to need help when performing this skill.",
+					"enum": [
+						"**---"
+					]
+				},
+				{
+					"description": "Intermediate experience: you are able to successfully complete tasks in this competency as requested. Help from an expert may be required from time to time, but you can usually perform the skill independently.",
+					"enum": [
+						"***--"
+					]
+				},
+				{
+					"description": "Advanced experience: you can perform the actions associated with this skill without assistance. You are certainly recognized within your immediate organization as \"a person to ask\" when difficult questions arise regarding this skill.",
+					"enum": [
+						"****-"
+					]
+				},
+				{
+					"description": "Expert: you are known as an expert in this area. You can provide guidance, troubleshoot and answer questions related to this area of expertise and the field where the skill is used.",
+					"enum": [
+						"*****"
+					]
+				}
 			]
 		},
 		"stringArray": {

--- a/index/$schema.proposal.json
+++ b/index/$schema.proposal.json
@@ -45,6 +45,7 @@
 			]
 		},
 		"proficiencyLevelEnum": {
+			"description": "Your experience in this proficiency.",
 			"oneOf": [
 				{
 					"description": "No experience. You really shouldn't list this unless necessary.",

--- a/index/$schema.proposal.json
+++ b/index/$schema.proposal.json
@@ -1,0 +1,280 @@
+{
+	"$schema": "http://json-schema.org/draft-06/schema",
+	"$id": "https://github.com/frontcore-io/index/index/$schema.proposal.json",
+	"title": "Frontcore IO Developer Schema (Proposal)",
+	"type": "object",
+	"definitions": {
+		"phoneNumber": {
+			"type": "string",
+			"pattern": "^\\+?[0-9]{10,11}$"
+		},
+		"proficiencyArea": {
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "#/definitions/proficiencyLevel"
+				},
+				{
+					"properties": {
+						"languages": {
+							"description": "(Optional) The (programming) languages you're proficient with in this area.",
+							"$ref": "#/definitions/proficiencyRefArray"
+						},
+						"frameworks": {
+							"description": "(Optional) The frameworks you're proficient with in this area.",
+							"$ref": "#/definitions/proficiencyRefArray"
+						},
+						"techniques": {
+							"description": "(Optional) The techniques you're proficient with in this area.",
+							"$ref": "#/definitions/proficiencyRefArray"
+						}
+					}
+				}
+			]
+		},
+		"proficiencyLevel": {
+			"type": "object",
+			"properties": {
+				"experience": {
+					"description": "Experience in this proficiency.",
+					"$ref": "#/definitions/proficiencyLevelEnum"
+				}
+			},
+			"required": [
+				"experience"
+			]
+		},
+		"proficiencyLevelEnum": {
+			"oneOf": [
+				{
+					"description": "No experience. You really shouldn't list this unless necessary.",
+					"enum": [
+						"-----"
+					]
+				},
+				{
+					"description": "Fundamental awareness: you have a common knowledge or an understanding of basic techniques and concepts.",
+					"enum": [
+						"*----"
+					]
+				},
+				{
+					"description": "Novice: you have the level of experience gained in a classroom and/or experimental scenarios or as a trainee on-the-job. You are expected to need help when performing this skill.",
+					"enum": [
+						"**---"
+					]
+				},
+				{
+					"description": "Intermediate experience: you are able to successfully complete tasks in this competency as requested. Help from an expert may be required from time to time, but you can usually perform the skill independently.",
+					"enum": [
+						"***--"
+					]
+				},
+				{
+					"description": "Advanced experience: you can perform the actions associated with this skill without assistance. You are certainly recognized within your immediate organization as \"a person to ask\" when difficult questions arise regarding this skill.",
+					"enum": [
+						"****-"
+					]
+				},
+				{
+					"description": "Expert: you are known as an expert in this area. You can provide guidance, troubleshoot and answer questions related to this area of expertise and the field where the skill is used.",
+					"enum": [
+						"*****"
+					]
+				}
+			]
+		},
+		"proficiencyRef": {
+			"oneOf": [
+				{
+					"type": "string"
+				},
+				{
+					"type": "object",
+					"properties": {
+						"experience": {
+							"$ref": "#/definitions/proficiencyLevelEnum"
+						},
+						"label": {
+							"description": "Label for this proficiency.",
+							"type": "string"
+						},
+						"url": {
+							"description": "URL to the website for this proficiency.",
+							"type": "string",
+							"format": "url"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"label"
+					]
+				}
+			]
+		},
+		"proficiencyRefArray": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/proficiencyRef"
+			},
+			"uniqueItems": true,
+			"default": []
+		},
+		"stringArray": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			},
+			"uniqueItems": true,
+			"default": []
+		}
+	},
+	"properties": {
+		"$schema": {
+			"type": "string",
+			"format": "uri"
+		},
+		"developer": {
+			"description": "All information that could be useful in contacting you.",
+			"type": "object",
+			"properties": {
+				"joinDate": {
+					"description": "The date you joined Frontcore.",
+					"type": "string",
+					"format": "date-time"
+				},
+				"firstName": {
+					"description": "Your first name.",
+					"type": "string",
+					"required": []
+				},
+				"lastNamePrefix": {
+					"description": "(Optional) Your last name prefix ('tussenvoegsel').",
+					"type": "string"
+				},
+				"lastName": {
+					"description": "Your last name.",
+					"type": "string",
+					"required": []
+				},
+				"phone": {
+					"description": "(Optional) Phone number(s) you can be reached at.",
+					"oneOf": [
+						{
+							"$ref": "#/definitions/phoneNumber"
+						},
+						{
+							"type": "array",
+							"minItems": 1,
+							"items": {
+								"$ref": "#/definitions/phoneNumber"
+							}
+						}
+					]
+				},
+				"email": {
+					"description": "(Optional) Email address(es) you can be reached at.",
+					"oneOf": [
+						{
+							"type": "string",
+							"format": "email"
+						},
+						{
+							"type": "array",
+							"minItems": 1,
+							"items": {
+								"type": "string",
+								"format": "email"
+							}
+						}
+					]
+				},
+				"links": {
+					"description": "(Optional) Websites/social media you can be reached at.",
+					"type": "object",
+					"properties": {
+						"facebook": {
+							"description": "(Optional) Your Facebook profile.",
+							"type": "string",
+							"format": "url",
+							"pattern": "^https://(www.)?facebook.com/"
+						},
+						"gitHub": {
+							"description": "(Optional) Your GitHub profile.",
+							"type": "string",
+							"format": "url",
+							"pattern": "^https://(www.)?github.com/"
+						},
+						"google": {
+							"description": "(Optional) Your Google+ profile.",
+							"type": "string",
+							"format": "url",
+							"pattern": "^https://plus.google.com/"
+						},
+						"home": {
+							"description": "(Optional) Your homepage.",
+							"type": "string",
+							"format": "url"
+						},
+						"linkedIn": {
+							"description": "(Optional) Your LinkedIn profile.",
+							"type": "string",
+							"format": "url",
+							"pattern": "^https://(www.)?linkedin.com/in/"
+						},
+						"other": {
+							"description": "(Optional) Contains all other websites. These will show up without an official icon.",
+							"type": "object",
+							"additionalProperties": {
+								"description": "An unmarked website.",
+								"type": "string",
+								"format": "url"
+							}
+						}
+					}
+				}
+			},
+			"required": [
+				"joinDate",
+				"firstName",
+				"lastName"
+			],
+			"additionalProperties": false
+		},
+		"skills": {
+			"description": "Your skills! Quite important, one would say.",
+			"type": "object",
+			"properties": {
+				"backend": {
+					"description": "(Optional) Your backend experience.",
+					"$ref": "#/definitions/proficiencyArea"
+				},
+				"frontend": {
+					"description": "(Optional) Your backend experience.",
+					"$ref": "#/definitions/proficiencyArea"
+				},
+				"other": {
+					"description": "(Optional) Other proficiencies you'd like to list.",
+					"type": "object",
+					"additionalProperties": {
+						"description": "A category or skill.",
+						"oneOf": [
+							{
+								"$ref": "#/definitions/proficiencyLevelEnum"
+							},
+							{
+								"$ref": "#/definitions/proficiencyArea"
+							}
+						]
+					}
+				}
+			},
+			"additionalProperties": false
+		}
+	},
+	"required": [
+		"developer",
+		"skills"
+	],
+	"additionalProperties": false
+}

--- a/index/melle.wynia.json
+++ b/index/melle.wynia.json
@@ -1,51 +1,44 @@
 {
-    "joinDate": "2017-07-20",
-
-    "firstName": "Melle",
-    "tussenvoegsel": "",
-    "lastName": "Wynia",
-
-    "phone": "0641017611",
-    "email": "frontcore@mellewynia.nl",
-    "url": "https://mellewynia.nl",
-    "linkedIn": "https://www.linkedin.com/in/melle-wynia/",
-    "gitHub": "https://github.com/mellewynia",
-
-    "consultancy": {
-      "level": "**---"
-    },
-
-    "lead": {
-      "level": "***--"
-    },
-
-    "design": {
-      "level": "**---",
-      "skills": [
-        "UX",
-        "Atomic"
-      ]
-    },
-
-    "frontend": {
-      "level": "****-",
-      "languages": [
-        "JavaScript",
-        "TypeScript",
-        "Pug"
-      ],
-      "frameworks": [
-        "Angular",
-        "Vue.js"
-      ],
-      "techniques": [
-        ""
-      ]
-    },
-
-    "backend": {
-      "level": "***--",
-      "languages": [""]
-    }
-
+	"$schema": "./$schema.json",
+	"joinDate": "2017-07-20",
+	"firstName": "Melle",
+	"lastNamePrefix": "",
+	"lastName": "Wynia",
+	"phone": "0641017611",
+	"email": "frontcore@mellewynia.nl",
+	"url": "https://mellewynia.nl",
+	"linkedIn": "https://www.linkedin.com/in/melle-wynia/",
+	"gitHub": "https://github.com/mellewynia",
+	"consultancy": {
+		"level": "**---"
+	},
+	"lead": {
+		"level": "***--"
+	},
+	"design": {
+		"level": "**---",
+		"skills": [
+			"UX",
+			"Atomic"
+		]
+	},
+	"frontend": {
+		"level": "****-",
+		"languages": [
+			"JavaScript",
+			"TypeScript",
+			"Pug"
+		],
+		"frameworks": [
+			"Angular",
+			"Vue.js"
+		],
+		"techniques": []
+	},
+	"backend": {
+		"level": "***--",
+		"languages": [
+			""
+		]
+	}
 }

--- a/index/sjuul.wijnia.json
+++ b/index/sjuul.wijnia.json
@@ -1,7 +1,42 @@
 {
 	"$schema": "./$schema.json",
+	"joinDate": "2017-07-20",
 	"firstName": "Sjuul",
-	"lastNamePrefix": "",
 	"lastName": "Wijnia",
-	"haha": ""
+	"phone": "0610745971",
+	"email": "sjuulwijnia@gmail.com",
+	"linkedIn": "https://www.linkedin.com/in/sjuul-wijnia-a75b719a/",
+	"gitHub": "https://github.com/sjuulwijnia",
+	"consultancy": {
+		"level": "***--"
+	},
+	"lead": {
+		"level": "*----"
+	},
+	"design": {
+		"level": "**---"
+	},
+	"frontend": {
+		"level": "****-",
+		"languages": [
+			"JavaScript",
+			"TypeScript",
+			"Pug",
+			"JSON Schema"
+		],
+		"frameworks": [
+			"Angular",
+			"AngularJS",
+			"FontoXML"
+		]
+	},
+	"backend": {
+		"level": "***--",
+		"languages": [
+			"C#"
+		],
+		"frameworks": [
+			"NHibernate"
+		]
+	}
 }

--- a/index/sjuul.wijnia.json
+++ b/index/sjuul.wijnia.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "./$schema.json",
+	"firstName": "Sjuul",
+	"lastNamePrefix": "",
+	"lastName": "Wijnia",
+	"haha": ""
+}

--- a/index/sjuul.wijnia.proposal.json
+++ b/index/sjuul.wijnia.proposal.json
@@ -1,0 +1,67 @@
+{
+	"$schema": "./$schema.proposal.json",
+	"developer": {
+		"firstName": "Sjuul",
+		"lastName": "Wijnia",
+		"joinDate": "2017-07-20",
+		"phone": [
+			"0610745971",
+			"+31610745971"
+		],
+		"email": [
+			"sjuulwijnia@gmail.com"
+		],
+		"links": {
+			"linkedIn": "https://www.linkedin.com/in/sjuul-wijnia-a75b719a/",
+			"gitHub": "https://github.com/sjuulwijnia",
+			"google": "https://plus.google.com/103843431901783823268",
+			"other": {
+				"YouTube": "https://www.youtube.com/channel/UC8lGpHhIVuMtzuCWgodD_Bw"
+			}
+		}
+	},
+	"skills": {
+		"backend": {
+			"experience": "***--",
+			"languages": [
+				"C#"
+			],
+			"frameworks": [
+				"NHibernate"
+			]
+		},
+		"frontend": {
+			"experience": "****-",
+			"languages": [
+				"JavaScript",
+				"TypeScript",
+				"Pug",
+				{
+					"label": "JSON Schema",
+					"experience": "***--",
+					"url": "http://json-schema.org/"
+				}
+			],
+			"frameworks": [
+				{
+					"label": "Angular",
+					"experience": "****-",
+					"url": "https://angular.io/"
+				},
+				"AngularJS",
+				"FontoXML"
+			]
+		},
+		"other": {
+			"Consultancy": "***--",
+			"Lead": "*----",
+			"Design": {
+				"experience": "**---",
+				"techniques": [
+					"UX",
+					"Atomic"
+				]
+			}
+		}
+	}
+}


### PR DESCRIPTION
Een voorstel voor de vormgeving van de lidbestanden. Sinds deze in JSON aangeleverd zullen worden, leek het Melle handig als hier een format voor vastgesteld is. D.m.v. [JSON schema's](http://json-schema.org/) deze opgezet, zowel gebaseerd op het eerste .json bestand (zie $schema.json) als een iets flexibeler voorstel van mijzelf (zie $schema.proposal.json).